### PR TITLE
Fix event routing: prefix-filter storage changes, deliver primitive payloads, support delimiter in topic names

### DIFF
--- a/__tests__/core/eventBus.test.ts
+++ b/__tests__/core/eventBus.test.ts
@@ -109,5 +109,57 @@ describe('eventBus.test.ts', () => {
         // then
         expect(result).toBeTruthy();
     });
+
+    it('should deliver primitive payloads like numbers',  async () => {
+        // given
+        const buffer = new DummyStorage()
+        const underTest = new EventBus(Config.of('test', '#', false), buffer);
+
+        let received: unknown = 'NOT CALLED';
+        await underTest.subscribe('numbers', (data: unknown) => {
+            received = data;
+        })
+
+        // when
+        await underTest.send('numbers', 10)
+
+        // then
+        expect(received).toBe(10);
+    });
+
+    it('should ignore storage changes that are not bus events',  async () => {
+        // given
+        const buffer = new DummyStorage()
+        const underTest = new EventBus(Config.of('test', '#', false), buffer);
+
+        let received: unknown = undefined;
+        await underTest.subscribe('settings', (data: unknown) => {
+            received = data;
+        })
+
+        // when: a foreign key changes in the same storage area
+        await buffer.save('user_settings_theme', { isEmpty: false, data: { theme: 'dark' } })
+
+        // then
+        expect(received).toBeUndefined();
+    });
+
+    it('should handle topic names containing the delimiter',  async () => {
+        // given
+        const topicName: string = 'my#topic';
+        const buffer = new DummyStorage()
+        const underTest = new EventBus(Config.of('test', '#', false), buffer);
+
+        let received: unknown = undefined;
+        await underTest.subscribe(topicName, (data: unknown) => {
+            received = data;
+        })
+
+        // when
+        await underTest.send(topicName, 'payload')
+
+        // then
+        expect(received).toBe('payload');
+    });
 });
 

--- a/dist/cjs/core/eventBus.js
+++ b/dist/cjs/core/eventBus.js
@@ -33,9 +33,10 @@ class EventBus {
         return this.listeners.has(topic);
     }
     async handle(map) {
+        const eventKeyPrefix = this.config.prefix + this.config.delimiter;
         for (let [key, value] of map.entries()) {
-            const topic = this.retrieveTopic(key);
-            if (key.includes(topic) && this.isNewEvent(value)) {
+            if (key.startsWith(eventKeyPrefix) && this.isNewEvent(value)) {
+                const topic = this.retrieveTopic(key);
                 console.info('[EventBus] Handling event with id: ' + key);
                 const listeners = this.listeners.get(topic);
                 if (listeners && listeners.length > 0) {
@@ -62,13 +63,18 @@ class EventBus {
         return new Date().getTime();
     }
     isEmptyEvent(data) {
-        return !data || Object.keys(data).length === 0;
+        if (data === undefined || data === null) {
+            return true;
+        }
+        return typeof data === 'object' && Object.keys(data).length === 0;
     }
     generateKey(topic) {
         return this.config.prefix + this.config.delimiter + topic + this.config.delimiter + this.getTime();
     }
     retrieveTopic(key) {
-        return key.split(this.config.delimiter)[1];
+        const start = this.config.prefix.length + this.config.delimiter.length;
+        const end = key.lastIndexOf(this.config.delimiter);
+        return key.substring(start, end);
     }
 }
 exports.default = EventBus;

--- a/dist/esm/core/eventBus.js
+++ b/dist/esm/core/eventBus.js
@@ -31,9 +31,10 @@ export default class EventBus {
         return this.listeners.has(topic);
     }
     async handle(map) {
+        const eventKeyPrefix = this.config.prefix + this.config.delimiter;
         for (let [key, value] of map.entries()) {
-            const topic = this.retrieveTopic(key);
-            if (key.includes(topic) && this.isNewEvent(value)) {
+            if (key.startsWith(eventKeyPrefix) && this.isNewEvent(value)) {
+                const topic = this.retrieveTopic(key);
                 console.info('[EventBus] Handling event with id: ' + key);
                 const listeners = this.listeners.get(topic);
                 if (listeners && listeners.length > 0) {
@@ -60,12 +61,17 @@ export default class EventBus {
         return new Date().getTime();
     }
     isEmptyEvent(data) {
-        return !data || Object.keys(data).length === 0;
+        if (data === undefined || data === null) {
+            return true;
+        }
+        return typeof data === 'object' && Object.keys(data).length === 0;
     }
     generateKey(topic) {
         return this.config.prefix + this.config.delimiter + topic + this.config.delimiter + this.getTime();
     }
     retrieveTopic(key) {
-        return key.split(this.config.delimiter)[1];
+        const start = this.config.prefix.length + this.config.delimiter.length;
+        const end = key.lastIndexOf(this.config.delimiter);
+        return key.substring(start, end);
     }
 }

--- a/src/core/eventBus.ts
+++ b/src/core/eventBus.ts
@@ -45,9 +45,10 @@ export default class EventBus implements IEventBus {
     }
 
     private async handle(map: Map<any, any>): Promise<void> {
+        const eventKeyPrefix: string = this.config.prefix + this.config.delimiter;
         for (let [key, value] of map.entries()) {
-            const topic: string = this.retrieveTopic(key);
-            if (key.includes(topic) && this.isNewEvent(value)) {
+            if (key.startsWith(eventKeyPrefix) && this.isNewEvent(value)) {
+                const topic: string = this.retrieveTopic(key);
                 console.info('[EventBus] Handling event with id: ' + key);
 
                 const listeners: Function[] | undefined = this.listeners.get(topic);
@@ -78,7 +79,11 @@ export default class EventBus implements IEventBus {
     }
 
     private isEmptyEvent(data: any): boolean {
-        return !data || Object.keys(data).length === 0;
+        if (data === undefined || data === null) {
+            return true;
+        }
+
+        return typeof data === 'object' && Object.keys(data).length === 0;
     }
 
     private generateKey(topic: string): string {
@@ -86,6 +91,8 @@ export default class EventBus implements IEventBus {
     }
 
     private retrieveTopic(key: string): string {
-        return key.split(this.config.delimiter)[1];
+        const start: number = this.config.prefix.length + this.config.delimiter.length;
+        const end: number = key.lastIndexOf(this.config.delimiter);
+        return key.substring(start, end);
     }
 }


### PR DESCRIPTION
# Problem

Three correctness bugs in `EventBus`:
1. Any `storage.local` change was treated as a bus event. The `key.includes(topic)` guard in `handle()` is always true because the topic is derived from the key itself. Unrelated extension storage writes were dispatched to subscribers, and with `removeOnceReceived` enabled the bus could delete storage keys it doesn't own.
2. Primitive payloads were dropped. `isEmptyEvent` used `!data || Object.keys(data).length === 0`, which classifies `0`, `''`, `false`, and every number (`Object.keys(10)` is `[]`) as empty — listeners were called with no arguments. The README example `send('numbers', 10)` delivered `undefined`.
3. Topics containing the delimiter mis-routed. `retrieveTopic` took `key.split(delimiter)[1]`, so `my_topic` with the default `_` delimiter routed to `my`.

# Fix

- `handle()` only processes keys starting with `prefix + delimiter`.
- `isEmptyEvent` treats only `undefined`/`null` and empty objects as empty; primitives pass through.
- `retrieveTopic` extracts the topic between the prefix and the trailing timestamp delimiter.

# Tests

Three new regression tests (primitive payload, foreign-key isolation, delimiter-in-topic); full suite 6/6 green. `dist/` rebuilt from source.
Out of scope (found during review, not changed)

- `send()` short-circuits when the local context has no subscribers, which prevents cross-context delivery — deliberate 0.5.0 behavior worth revisiting.
- Same-millisecond sends to one topic collide on the timestamp key and lose the second event.
- `package.json` exports blocks the deep import path the README suggests.